### PR TITLE
Fix for RN 0.18

### DIFF
--- a/RNCalendarReminders.m
+++ b/RNCalendarReminders.m
@@ -47,7 +47,7 @@ RCT_EXPORT_MODULE()
 - (void)authorizationStatusForAccessEventStore
 {
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:EKEntityTypeReminder];
-
+    
     switch (status) {
         case EKAuthorizationStatusDenied:
         case EKAuthorizationStatusRestricted: {
@@ -89,7 +89,7 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-
+    
     EKReminder *reminder = [EKReminder reminderWithEventStore:self.eventStore];
     reminder.calendar = [self.eventStore defaultCalendarForNewReminders];
     reminder.title = title;
@@ -98,18 +98,18 @@ RCT_EXPORT_MODULE()
     reminder.startDateComponents = startDateComponents;
     reminder.completed = NO;
     reminder.notes = notes;
-
+    
     if (alarms) {
         reminder.alarms = [self createReminderAlarms:alarms];
     }
-
+    
     if (recurrence) {
         EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence];
         if (rule) {
             reminder.recurrenceRules = [NSArray arrayWithObject:rule];
         }
     }
-
+    
     [self saveReminder:reminder];
 }
 
@@ -125,24 +125,24 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-
+    
     reminder.title = title;
     reminder.location = location;
     reminder.dueDateComponents = startDateComponents;
     reminder.startDateComponents = startDateComponents;
     reminder.notes = notes;
-
+    
     if (alarms) {
         reminder.alarms = [self createReminderAlarms:alarms];
     }
-
+    
     if (recurrence) {
         EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence];
         if (rule) {
             reminder.recurrenceRules = [NSArray arrayWithObject:rule];
         }
     }
-
+    
     [self saveReminder:reminder];
 }
 
@@ -151,7 +151,7 @@ RCT_EXPORT_MODULE()
 {
     NSError *error = nil;
     BOOL success = [self.eventStore saveReminder:reminder commit:YES error:&error];
-
+    
     if (!success) {
         [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminderError"
                                                      body:@{@"error": @"Error saving reminder"}];
@@ -167,11 +167,11 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-
+    
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     NSError *error = nil;
     BOOL success = [self.eventStore removeReminder:reminder commit:YES error:&error];
-
+    
     if (!success) {
         [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminderError"
                                                      body:@{@"error": @"Error removing reminder"}];
@@ -185,7 +185,7 @@ RCT_EXPORT_MODULE()
 {
     EKAlarm *reminderAlarm = nil;
     id alarmDate = [alarm valueForKey:@"date"];
-
+    
     if ([alarmDate isKindOfClass:[NSString class]]) {
         reminderAlarm = [EKAlarm alarmWithAbsoluteDate:[RCTConvert NSDate:alarmDate]];
     } else if ([alarmDate isKindOfClass:[NSNumber class]]) {
@@ -194,17 +194,17 @@ RCT_EXPORT_MODULE()
     } else {
         reminderAlarm = [[EKAlarm alloc] init];
     }
-
+    
     if ([alarm objectForKey:@"structuredLocation"] && [[alarm objectForKey:@"structuredLocation"] count]) {
         NSDictionary *locationOptions = [alarm valueForKey:@"structuredLocation"];
         NSDictionary *geo = [locationOptions valueForKey:@"coords"];
         CLLocation *geoLocation = [[CLLocation alloc] initWithLatitude:[[geo valueForKey:@"latitude"] doubleValue]
                                                              longitude:[[geo valueForKey:@"longitude"] doubleValue]];
-
+        
         reminderAlarm.structuredLocation = [EKStructuredLocation locationWithTitle:[locationOptions valueForKey:@"title"]];
         reminderAlarm.structuredLocation.geoLocation = geoLocation;
         reminderAlarm.structuredLocation.radius = [[locationOptions valueForKey:@"radius"] doubleValue];
-
+        
         if ([[locationOptions valueForKey:@"proximity"] isEqualToString:@"enter"]) {
             reminderAlarm.proximity = EKAlarmProximityEnter;
         } else if ([[locationOptions valueForKey:@"proximity"] isEqualToString:@"leave"]) {
@@ -233,11 +233,11 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-
+    
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     EKAlarm *reminderAlarm = [self createReminderAlarm:alarm];
     [reminder addAlarm:reminderAlarm];
-
+    
     [self saveReminder:reminder];
 }
 
@@ -247,10 +247,10 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-
+    
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     reminder.alarms = [self createReminderAlarms:alarms];
-
+    
     [self saveReminder:reminder];
 }
 
@@ -260,7 +260,7 @@ RCT_EXPORT_MODULE()
 -(EKRecurrenceFrequency)frequencyMatchingName:(NSString *)name
 {
     EKRecurrenceFrequency recurrence = EKRecurrenceFrequencyDaily;
-
+    
     if ([name isEqualToString:@"weekly"]) {
         recurrence = EKRecurrenceFrequencyWeekly;
     } else if ([name isEqualToString:@"monthly"]) {
@@ -275,7 +275,7 @@ RCT_EXPORT_MODULE()
 {
     EKRecurrenceRule *rule = nil;
     NSArray *validFrequencyTypes = @[@"daily", @"weekly", @"monthly", @"yearly"];
-
+    
     if ([validFrequencyTypes containsObject:frequency]) {
         rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency:[self frequencyMatchingName:frequency]
                                                             interval:1
@@ -304,7 +304,7 @@ RCT_EXPORT_MODULE()
 - (NSArray *)serializeReminders:(NSArray *)reminders
 {
     NSMutableArray *serializedReminders = [[NSMutableArray alloc] init];
-
+    
     NSDictionary *emptyReminder = @{
                                     _title: @"",
                                     _location: @"",
@@ -313,42 +313,42 @@ RCT_EXPORT_MODULE()
                                     _alarms: @[],
                                     _recurrence: @""
                                     };
-
+    
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     NSTimeZone *timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
     [dateFormatter setTimeZone:timeZone];
     [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setDateFormat: @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z"];
-
+    
     for (EKReminder *reminder in reminders) {
-
+        
         NSMutableDictionary *formedReminder = [NSMutableDictionary dictionaryWithDictionary:emptyReminder];
-
+        
         if (reminder.calendarItemIdentifier) {
             [formedReminder setValue:reminder.calendarItemIdentifier forKey:_id];
         }
-
+        
         if (reminder.title) {
             [formedReminder setValue:reminder.title forKey:_title];
         }
-
+        
         if (reminder.notes) {
             [formedReminder setValue:reminder.notes forKey:_notes];
         }
-
+        
         if (reminder.location) {
             [formedReminder setValue:reminder.location forKey:_location];
         }
-
+        
         if (reminder.hasAlarms) {
             NSMutableArray *alarms = [[NSMutableArray alloc] init];
-
+            
             for (EKAlarm *alarm in reminder.alarms) {
-
+                
                 NSMutableDictionary *formattedAlarm = [[NSMutableDictionary alloc] init];
                 NSString *alarmDate = nil;
-
+                
                 if (alarm.absoluteDate) {
                     alarmDate = [dateFormatter stringFromDate:alarm.absoluteDate];
                 } else if (alarm.relativeOffset) {
@@ -362,7 +362,7 @@ RCT_EXPORT_MODULE()
                                                                                  sinceDate:reminderStartDate]];
                 }
                 [formattedAlarm setValue:alarmDate forKey:@"date"];
-
+                
                 if (alarm.structuredLocation) {
                     NSString *proximity = nil;
                     switch (alarm.proximity) {
@@ -385,13 +385,13 @@ RCT_EXPORT_MODULE()
                                                        @"longitude": @(alarm.structuredLocation.geoLocation.coordinate.longitude)
                                                        }}
                                       forKey:@"structuredLocation"];
-
+                    
                 }
                 [alarms addObject:formattedAlarm];
             }
             [formedReminder setValue:alarms forKey:_alarms];
         }
-
+        
         if (reminder.startDateComponents) {
             NSDate *reminderStartDate = [calendar dateFromComponents:reminder.startDateComponents];
             [formedReminder setValue:[dateFormatter stringFromDate:reminderStartDate] forKey:_startDate];
@@ -401,10 +401,10 @@ RCT_EXPORT_MODULE()
             NSString *frequencyType = [self nameMatchingFrequency:[[reminder.recurrenceRules objectAtIndex:0] frequency]];
             [formedReminder setValue:frequencyType forKey:_recurrence];
         }
-
+        
         [serializedReminders addObject:formedReminder];
     }
-
+    
     return [serializedReminders copy];
 }
 
@@ -423,7 +423,7 @@ RCT_EXPORT_MODULE()
 - (void)calendarEventReminderReceived:(NSNotification *)notification
 {
     NSPredicate *predicate = [self.eventStore predicateForRemindersInCalendars:nil];
-
+    
     __weak RNCalendarReminders *weakSelf = self;
     [self.eventStore fetchRemindersMatchingPredicate:predicate completion:^(NSArray *reminders) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -450,7 +450,7 @@ RCT_EXPORT_METHOD(authorizeEventStore:(RCTResponseSenderBlock)callback)
 RCT_EXPORT_METHOD(fetchAllReminders:(RCTResponseSenderBlock)callback)
 {
     NSPredicate *predicate = [self.eventStore predicateForRemindersInCalendars:nil];
-
+    
     __weak RNCalendarReminders *weakSelf = self;
     [self.eventStore fetchRemindersMatchingPredicate:predicate completion:^(NSArray *reminders) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -468,11 +468,11 @@ RCT_EXPORT_METHOD(saveReminder:(NSString *)title details:(NSDictionary *)details
     NSString *notes = [RCTConvert NSString:details[_notes]];
     NSArray *alarms = [RCTConvert NSArray:details[_alarms]];
     NSString *recurrence = [RCTConvert NSString:details[_recurrence]];
-
+    
     NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateComponents *startDateComponents = [gregorianCalendar components:(NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit)
                                                                  fromDate:startDate];
-
+    
     if (eventId) {
         EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
         [self editReminder:reminder
@@ -482,7 +482,7 @@ RCT_EXPORT_METHOD(saveReminder:(NSString *)title details:(NSDictionary *)details
                      notes:notes
                     alarms:alarms
                 recurrence:recurrence];
-
+        
     } else {
         [self addReminder:title
                 startDate:startDateComponents

--- a/RNCalendarReminders.m
+++ b/RNCalendarReminders.m
@@ -47,7 +47,7 @@ RCT_EXPORT_MODULE()
 - (void)authorizationStatusForAccessEventStore
 {
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:EKEntityTypeReminder];
-    
+
     switch (status) {
         case EKAuthorizationStatusDenied:
         case EKAuthorizationStatusRestricted: {
@@ -89,7 +89,7 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-    
+
     EKReminder *reminder = [EKReminder reminderWithEventStore:self.eventStore];
     reminder.calendar = [self.eventStore defaultCalendarForNewReminders];
     reminder.title = title;
@@ -98,18 +98,18 @@ RCT_EXPORT_MODULE()
     reminder.startDateComponents = startDateComponents;
     reminder.completed = NO;
     reminder.notes = notes;
-    
+
     if (alarms) {
         reminder.alarms = [self createReminderAlarms:alarms];
     }
-    
+
     if (recurrence) {
         EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence];
         if (rule) {
             reminder.recurrenceRules = [NSArray arrayWithObject:rule];
         }
     }
-    
+
     [self saveReminder:reminder];
 }
 
@@ -125,24 +125,24 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-    
+
     reminder.title = title;
     reminder.location = location;
     reminder.dueDateComponents = startDateComponents;
     reminder.startDateComponents = startDateComponents;
     reminder.notes = notes;
-    
+
     if (alarms) {
         reminder.alarms = [self createReminderAlarms:alarms];
     }
-    
+
     if (recurrence) {
         EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence];
         if (rule) {
             reminder.recurrenceRules = [NSArray arrayWithObject:rule];
         }
     }
-    
+
     [self saveReminder:reminder];
 }
 
@@ -151,12 +151,12 @@ RCT_EXPORT_MODULE()
 {
     NSError *error = nil;
     BOOL success = [self.eventStore saveReminder:reminder commit:YES error:&error];
-    
+
     if (!success) {
-        [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminderError"
+        [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminderError"
                                                      body:@{@"error": @"Error saving reminder"}];
     } else {
-        [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminderSaved"
+        [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminderSaved"
                                                      body:reminder.calendarItemIdentifier];
     }
 }
@@ -167,13 +167,13 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-    
+
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     NSError *error = nil;
     BOOL success = [self.eventStore removeReminder:reminder commit:YES error:&error];
-    
+
     if (!success) {
-        [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminderError"
+        [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminderError"
                                                      body:@{@"error": @"Error removing reminder"}];
     }
 }
@@ -185,7 +185,7 @@ RCT_EXPORT_MODULE()
 {
     EKAlarm *reminderAlarm = nil;
     id alarmDate = [alarm valueForKey:@"date"];
-    
+
     if ([alarmDate isKindOfClass:[NSString class]]) {
         reminderAlarm = [EKAlarm alarmWithAbsoluteDate:[RCTConvert NSDate:alarmDate]];
     } else if ([alarmDate isKindOfClass:[NSNumber class]]) {
@@ -194,17 +194,17 @@ RCT_EXPORT_MODULE()
     } else {
         reminderAlarm = [[EKAlarm alloc] init];
     }
-    
+
     if ([alarm objectForKey:@"structuredLocation"] && [[alarm objectForKey:@"structuredLocation"] count]) {
         NSDictionary *locationOptions = [alarm valueForKey:@"structuredLocation"];
         NSDictionary *geo = [locationOptions valueForKey:@"coords"];
         CLLocation *geoLocation = [[CLLocation alloc] initWithLatitude:[[geo valueForKey:@"latitude"] doubleValue]
                                                              longitude:[[geo valueForKey:@"longitude"] doubleValue]];
-        
+
         reminderAlarm.structuredLocation = [EKStructuredLocation locationWithTitle:[locationOptions valueForKey:@"title"]];
         reminderAlarm.structuredLocation.geoLocation = geoLocation;
         reminderAlarm.structuredLocation.radius = [[locationOptions valueForKey:@"radius"] doubleValue];
-        
+
         if ([[locationOptions valueForKey:@"proximity"] isEqualToString:@"enter"]) {
             reminderAlarm.proximity = EKAlarmProximityEnter;
         } else if ([[locationOptions valueForKey:@"proximity"] isEqualToString:@"leave"]) {
@@ -233,11 +233,11 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-    
+
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     EKAlarm *reminderAlarm = [self createReminderAlarm:alarm];
     [reminder addAlarm:reminderAlarm];
-    
+
     [self saveReminder:reminder];
 }
 
@@ -247,10 +247,10 @@ RCT_EXPORT_MODULE()
     if (!self.isAccessToEventStoreGranted) {
         return;
     }
-    
+
     EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
     reminder.alarms = [self createReminderAlarms:alarms];
-    
+
     [self saveReminder:reminder];
 }
 
@@ -260,7 +260,7 @@ RCT_EXPORT_MODULE()
 -(EKRecurrenceFrequency)frequencyMatchingName:(NSString *)name
 {
     EKRecurrenceFrequency recurrence = EKRecurrenceFrequencyDaily;
-    
+
     if ([name isEqualToString:@"weekly"]) {
         recurrence = EKRecurrenceFrequencyWeekly;
     } else if ([name isEqualToString:@"monthly"]) {
@@ -275,7 +275,7 @@ RCT_EXPORT_MODULE()
 {
     EKRecurrenceRule *rule = nil;
     NSArray *validFrequencyTypes = @[@"daily", @"weekly", @"monthly", @"yearly"];
-    
+
     if ([validFrequencyTypes containsObject:frequency]) {
         rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency:[self frequencyMatchingName:frequency]
                                                             interval:1
@@ -304,7 +304,7 @@ RCT_EXPORT_MODULE()
 - (NSArray *)serializeReminders:(NSArray *)reminders
 {
     NSMutableArray *serializedReminders = [[NSMutableArray alloc] init];
-    
+
     NSDictionary *emptyReminder = @{
                                     _title: @"",
                                     _location: @"",
@@ -313,42 +313,42 @@ RCT_EXPORT_MODULE()
                                     _alarms: @[],
                                     _recurrence: @""
                                     };
-    
+
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     NSTimeZone *timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
     [dateFormatter setTimeZone:timeZone];
     [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setDateFormat: @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z"];
-    
+
     for (EKReminder *reminder in reminders) {
-        
+
         NSMutableDictionary *formedReminder = [NSMutableDictionary dictionaryWithDictionary:emptyReminder];
-        
+
         if (reminder.calendarItemIdentifier) {
             [formedReminder setValue:reminder.calendarItemIdentifier forKey:_id];
         }
-        
+
         if (reminder.title) {
             [formedReminder setValue:reminder.title forKey:_title];
         }
-        
+
         if (reminder.notes) {
             [formedReminder setValue:reminder.notes forKey:_notes];
         }
-        
+
         if (reminder.location) {
             [formedReminder setValue:reminder.location forKey:_location];
         }
-        
+
         if (reminder.hasAlarms) {
             NSMutableArray *alarms = [[NSMutableArray alloc] init];
-            
+
             for (EKAlarm *alarm in reminder.alarms) {
-                
+
                 NSMutableDictionary *formattedAlarm = [[NSMutableDictionary alloc] init];
                 NSString *alarmDate = nil;
-                
+
                 if (alarm.absoluteDate) {
                     alarmDate = [dateFormatter stringFromDate:alarm.absoluteDate];
                 } else if (alarm.relativeOffset) {
@@ -362,7 +362,7 @@ RCT_EXPORT_MODULE()
                                                                                  sinceDate:reminderStartDate]];
                 }
                 [formattedAlarm setValue:alarmDate forKey:@"date"];
-                
+
                 if (alarm.structuredLocation) {
                     NSString *proximity = nil;
                     switch (alarm.proximity) {
@@ -385,13 +385,13 @@ RCT_EXPORT_MODULE()
                                                        @"longitude": @(alarm.structuredLocation.geoLocation.coordinate.longitude)
                                                        }}
                                       forKey:@"structuredLocation"];
-                    
+
                 }
                 [alarms addObject:formattedAlarm];
             }
             [formedReminder setValue:alarms forKey:_alarms];
         }
-        
+
         if (reminder.startDateComponents) {
             NSDate *reminderStartDate = [calendar dateFromComponents:reminder.startDateComponents];
             [formedReminder setValue:[dateFormatter stringFromDate:reminderStartDate] forKey:_startDate];
@@ -401,10 +401,10 @@ RCT_EXPORT_MODULE()
             NSString *frequencyType = [self nameMatchingFrequency:[[reminder.recurrenceRules objectAtIndex:0] frequency]];
             [formedReminder setValue:frequencyType forKey:_recurrence];
         }
-        
+
         [serializedReminders addObject:formedReminder];
     }
-    
+
     return [serializedReminders copy];
 }
 
@@ -423,11 +423,11 @@ RCT_EXPORT_MODULE()
 - (void)calendarEventReminderReceived:(NSNotification *)notification
 {
     NSPredicate *predicate = [self.eventStore predicateForRemindersInCalendars:nil];
-    
+
     __weak RNCalendarReminders *weakSelf = self;
     [self.eventStore fetchRemindersMatchingPredicate:predicate completion:^(NSArray *reminders) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf.bridge.eventDispatcher sendAppEventWithName:@"EventReminder"
+            [weakSelf.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminder"
                                                              body:[weakSelf serializeReminders:reminders]];
         });
     }];
@@ -450,7 +450,7 @@ RCT_EXPORT_METHOD(authorizeEventStore:(RCTResponseSenderBlock)callback)
 RCT_EXPORT_METHOD(fetchAllReminders:(RCTResponseSenderBlock)callback)
 {
     NSPredicate *predicate = [self.eventStore predicateForRemindersInCalendars:nil];
-    
+
     __weak RNCalendarReminders *weakSelf = self;
     [self.eventStore fetchRemindersMatchingPredicate:predicate completion:^(NSArray *reminders) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -468,11 +468,11 @@ RCT_EXPORT_METHOD(saveReminder:(NSString *)title details:(NSDictionary *)details
     NSString *notes = [RCTConvert NSString:details[_notes]];
     NSArray *alarms = [RCTConvert NSArray:details[_alarms]];
     NSString *recurrence = [RCTConvert NSString:details[_recurrence]];
-    
+
     NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateComponents *startDateComponents = [gregorianCalendar components:(NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit)
                                                                  fromDate:startDate];
-    
+
     if (eventId) {
         EKReminder *reminder = (EKReminder *)[self.eventStore calendarItemWithIdentifier:eventId];
         [self editReminder:reminder
@@ -482,7 +482,7 @@ RCT_EXPORT_METHOD(saveReminder:(NSString *)title details:(NSDictionary *)details
                      notes:notes
                     alarms:alarms
                 recurrence:recurrence];
-        
+
     } else {
         [self addReminder:title
                 startDate:startDateComponents


### PR DESCRIPTION
Good morning,

I recently upgraded a project to React Native 0.18 and ran into this error:

```
Module RCTNativeAppEventEmitter is not a registered callable module.
```

After some digging I figured out that it was the Calendar Reminders module and found this [issue](https://github.com/facebook/react-native/pull/918).  I then changed the `sendAppEvent` calls to `sendDeviceEvent` and things worked.

Making that change also fixed the warnings I was getting:

```
Warning: Failed propType: Invalid prop `date` of type `Number` supplied to `RCTDatePicker`, expected instance of `Date`
ExceptionsManager.js:76 Warning: Failed propType: Required prop `onDateChange` was not specified in `RCTDatePicker`. Check the render method of `DatePickerIOS`
```

Not 100% sure if those warnings have to do with the Reminders module or the DatePicker module, but either way they went away when I made the change.

Also, from the 918 issue there might be another way to solve the RCTNativeAppEventEmitter error, but I didn't spend a whole lot of time tracking that down since changing to the DeviceEventEmitter solved the problem.

Thanks,
Adam
