### PR TITLE
Customize recurrence intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ import {NativeAppEventEmitter} from 'react-native';
 | notes           | String           | The notes associated with the reminder. |
 | alarms          | Array            | The alarms associated with the reminder, as an array of alarm objects. |
 | recurrence      | String           | The simple recurrence frequency of the reminder ['daily', 'weekly', 'monthly', 'yearly']. |
+| recurrenceInterval | String        | The interval between instances of this recurrence. For example, a weekly recurrence rule with an interval of 2 occurs every other week. Must be greater than 0. |
 | isCompleted     | Bool             | A Boolean value determining whether or not the reminder is marked completed. |
 
 ## Events
@@ -147,6 +148,21 @@ RNCalendarReminders.saveReminder('title', {
     date: -1 // or absolute date
   }],
   recurrence: 'daily'
+});
+```
+
+Example with recurrenceInterval:
+
+```javascript
+RNCalendarReminders.saveReminder('title', {
+  location: 'location',
+  notes: 'notes',
+  startDate: '2016-10-01T09:45:00.000UTC',
+  alarms: [{
+    date: -1 // or absolute date
+  }],
+  recurrence: 'weekly',
+  recurrenceInterval: '2'
 });
 ```
 

--- a/RNCalendarReminders.m
+++ b/RNCalendarReminders.m
@@ -17,6 +17,7 @@ static NSString *const _completionDate = @"completionDate";
 static NSString *const _notes = @"notes";
 static NSString *const _alarms = @"alarms";
 static NSString *const _recurrence = @"recurrence";
+static NSString *const _recurrenceInterval = @"recurrenceInterval";
 static NSString *const _isCompleted = @"isCompleted";
 
 @implementation RNCalendarReminders
@@ -103,6 +104,8 @@ RCT_EXPORT_MODULE()
     NSString *notes = [RCTConvert NSString:details[_notes]];
     NSArray *alarms = [RCTConvert NSArray:details[_alarms]];
     NSString *recurrence = [RCTConvert NSString:details[_recurrence]];
+    NSString *recurrenceIntervalString = [RCTConvert NSString:details[_recurrenceInterval]];
+    NSInteger recurrenceInterval = [recurrenceIntervalString integerValue];
     BOOL *isCompleted = [RCTConvert BOOL:details[_isCompleted]];
     
     NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
@@ -130,7 +133,7 @@ RCT_EXPORT_MODULE()
         reminder.alarms = [self createReminderAlarms:alarms];
     }
     if (recurrence) {
-        EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence];
+        EKRecurrenceRule *rule = [self createRecurrenceRule:recurrence :recurrenceInterval];
         if (rule) {
             reminder.recurrenceRules = [NSArray arrayWithObject:rule];
         }
@@ -267,14 +270,14 @@ RCT_EXPORT_MODULE()
     return recurrence;
 }
 
--(EKRecurrenceRule *)createRecurrenceRule:(NSString *)frequency
+-(EKRecurrenceRule *)createRecurrenceRule:(NSString *)frequency :(int)recurrenceInterval
 {
     EKRecurrenceRule *rule = nil;
     NSArray *validFrequencyTypes = @[@"daily", @"weekly", @"monthly", @"yearly"];
     
     if ([validFrequencyTypes containsObject:frequency]) {
         rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency:[self frequencyMatchingName:frequency]
-                                                            interval:1
+                                                            interval:recurrenceInterval
                                                                  end:nil];
     }
     return rule;


### PR DESCRIPTION
This adds a new interval parameter to create recurring reminders:

| Property | Value | Description |
| :-- | :-- | :-- |
| recurrenceInterval | String | The interval between instances of this recurrence. For example, a weekly recurrence rule with an interval of 2 occurs every other week. Must be greater than 0. |

This fixes https://github.com/wmcmahan/React-Native-Calendar-Reminders/issues/23
### Still TODO:
- [ ] Default to `recurrenceInterval = 1`, if it's not passed in.
### Could also:
- [ ] Take `reccurenceInterval` as a `Number`, instead of as a `String`.
